### PR TITLE
Support EKS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "aws-auth-payload"
 version = "0.1.0"
-source = "git+https://github.com/lawliet89/aws-auth-payload?rev=763babe2a5a257dc37060cb450c0b23a13bd4fdf#763babe2a5a257dc37060cb450c0b23a13bd4fdf"
+source = "git+https://github.com/lawliet89/aws-auth-payload?rev=63eaf88856b284b4864f46e578e5aabb87d352a9#63eaf88856b284b4864f46e578e5aabb87d352a9"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -74,8 +74,7 @@ dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_core 0.39.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_sts 0.39.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_core 0.39.0 (git+https://github.com/basisai/rusoto.git?rev=5a66c42296063ff021273827f12e629ae60a4716)",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1146,7 +1145,7 @@ dependencies = [
 [[package]]
 name = "rusoto_core"
 version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/basisai/rusoto.git?rev=5a66c42296063ff021273827f12e629ae60a4716#5a66c42296063ff021273827f12e629ae60a4716"
 dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1159,7 +1158,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "md5 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_credential 0.39.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_credential 0.39.0 (git+https://github.com/basisai/rusoto.git?rev=5a66c42296063ff021273827f12e629ae60a4716)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1175,7 +1174,7 @@ dependencies = [
 [[package]]
 name = "rusoto_credential"
 version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/basisai/rusoto.git?rev=5a66c42296063ff021273827f12e629ae60a4716#5a66c42296063ff021273827f12e629ae60a4716"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1188,19 +1187,6 @@ dependencies = [
  "shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-process 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rusoto_sts"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_core 0.39.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1784,7 +1770,7 @@ dependencies = [
 name = "vault-k8s-helper"
 version = "0.2.0"
 dependencies = [
- "aws-auth-payload 0.1.0 (git+https://github.com/lawliet89/aws-auth-payload?rev=763babe2a5a257dc37060cb450c0b23a13bd4fdf)",
+ "aws-auth-payload 0.1.0 (git+https://github.com/lawliet89/aws-auth-payload?rev=63eaf88856b284b4864f46e578e5aabb87d352a9)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1792,17 +1778,17 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_core 0.39.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_core 0.39.0 (git+https://github.com/basisai/rusoto.git?rev=5a66c42296063ff021273827f12e629ae60a4716)",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "vault-rs 0.1.0 (git+https://github.com/lawliet89/vault-rs?rev=416d4f0fa704af36f5116ebd8b8d37e483658922)",
+ "vault-rs 0.1.0 (git+https://github.com/lawliet89/vault-rs?rev=34a6c73b900114fdfdbf0597c66f1e324e894012)",
 ]
 
 [[package]]
 name = "vault-rs"
 version = "0.1.0"
-source = "git+https://github.com/lawliet89/vault-rs?rev=416d4f0fa704af36f5116ebd8b8d37e483658922#416d4f0fa704af36f5116ebd8b8d37e483658922"
+source = "git+https://github.com/lawliet89/vault-rs?rev=34a6c73b900114fdfdbf0597c66f1e324e894012#34a6c73b900114fdfdbf0597c66f1e324e894012"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1911,7 +1897,7 @@ dependencies = [
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf"
-"checksum aws-auth-payload 0.1.0 (git+https://github.com/lawliet89/aws-auth-payload?rev=763babe2a5a257dc37060cb450c0b23a13bd4fdf)" = "<none>"
+"checksum aws-auth-payload 0.1.0 (git+https://github.com/lawliet89/aws-auth-payload?rev=63eaf88856b284b4864f46e578e5aabb87d352a9)" = "<none>"
 "checksum backtrace 0.3.30 (registry+https://github.com/rust-lang/crates.io-index)" = "ada4c783bb7e7443c14e0480f429ae2cc99da95065aeab7ee1b81ada0419404f"
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
@@ -2032,9 +2018,8 @@ dependencies = [
 "checksum regex-syntax 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d76410686f9e3a17f06128962e0ecc5755870bb890c34820c7af7f1db2e1d48"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum reqwest 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)" = "00eb63f212df0e358b427f0f40aa13aaea010b470be642ad422bcbca2feff2e4"
-"checksum rusoto_core 0.39.0 (registry+https://github.com/rust-lang/crates.io-index)" = "42753f93bf02ca5d177b85dfbfde7e8011ee330b3a5576584b99da3443d26da8"
-"checksum rusoto_credential 0.39.0 (registry+https://github.com/rust-lang/crates.io-index)" = "adbb49748d537ead58aa70042655ce730ea4da511babbb9e7238a869b9d240ea"
-"checksum rusoto_sts 0.39.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8651edfe8e1029b6057e6c28321ac9b95d3660ac3848e4bbcf9d8bbd1a7ed4df"
+"checksum rusoto_core 0.39.0 (git+https://github.com/basisai/rusoto.git?rev=5a66c42296063ff021273827f12e629ae60a4716)" = "<none>"
+"checksum rusoto_credential 0.39.0 (git+https://github.com/basisai/rusoto.git?rev=5a66c42296063ff021273827f12e629ae60a4716)" = "<none>"
 "checksum rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f4dccf6f4891ebcc0c39f9b6eb1a83b9bf5d747cb439ec6fba4f3b977038af"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "b96a9549dc8d48f2c283938303c4b5a77aa29bfbc5b54b084fb1630408899a8f"
@@ -2099,7 +2084,7 @@ dependencies = [
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum utf8-ranges 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9d50aa7650df78abf942826607c62468ce18d9019673d4a2ebe1865dbb96ffde"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
-"checksum vault-rs 0.1.0 (git+https://github.com/lawliet89/vault-rs?rev=416d4f0fa704af36f5116ebd8b8d37e483658922)" = "<none>"
+"checksum vault-rs 0.1.0 (git+https://github.com/lawliet89/vault-rs?rev=34a6c73b900114fdfdbf0597c66f1e324e894012)" = "<none>"
 "checksum vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "aws-auth-payload"
 version = "0.1.0"
-source = "git+https://github.com/lawliet89/aws-auth-payload?rev=63eaf88856b284b4864f46e578e5aabb87d352a9#63eaf88856b284b4864f46e578e5aabb87d352a9"
+source = "git+https://github.com/lawliet89/aws-auth-payload?rev=a760bfd02bca926a9d7e5c66ed5779939dc98b29#a760bfd02bca926a9d7e5c66ed5779939dc98b29"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -74,7 +74,7 @@ dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_core 0.39.0 (git+https://github.com/basisai/rusoto.git?rev=5a66c42296063ff021273827f12e629ae60a4716)",
+ "rusoto_core 0.39.0 (git+https://github.com/basisai/rusoto.git?rev=c1965504b483d1b086844a28742778cc64467863)",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1145,7 +1145,7 @@ dependencies = [
 [[package]]
 name = "rusoto_core"
 version = "0.39.0"
-source = "git+https://github.com/basisai/rusoto.git?rev=5a66c42296063ff021273827f12e629ae60a4716#5a66c42296063ff021273827f12e629ae60a4716"
+source = "git+https://github.com/basisai/rusoto.git?rev=c1965504b483d1b086844a28742778cc64467863#c1965504b483d1b086844a28742778cc64467863"
 dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1158,7 +1158,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "md5 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_credential 0.39.0 (git+https://github.com/basisai/rusoto.git?rev=5a66c42296063ff021273827f12e629ae60a4716)",
+ "rusoto_credential 0.39.0 (git+https://github.com/basisai/rusoto.git?rev=c1965504b483d1b086844a28742778cc64467863)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1174,7 +1174,7 @@ dependencies = [
 [[package]]
 name = "rusoto_credential"
 version = "0.39.0"
-source = "git+https://github.com/basisai/rusoto.git?rev=5a66c42296063ff021273827f12e629ae60a4716#5a66c42296063ff021273827f12e629ae60a4716"
+source = "git+https://github.com/basisai/rusoto.git?rev=c1965504b483d1b086844a28742778cc64467863#c1965504b483d1b086844a28742778cc64467863"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1770,7 +1770,7 @@ dependencies = [
 name = "vault-k8s-helper"
 version = "0.2.0"
 dependencies = [
- "aws-auth-payload 0.1.0 (git+https://github.com/lawliet89/aws-auth-payload?rev=63eaf88856b284b4864f46e578e5aabb87d352a9)",
+ "aws-auth-payload 0.1.0 (git+https://github.com/lawliet89/aws-auth-payload?rev=a760bfd02bca926a9d7e5c66ed5779939dc98b29)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1778,7 +1778,7 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_core 0.39.0 (git+https://github.com/basisai/rusoto.git?rev=5a66c42296063ff021273827f12e629ae60a4716)",
+ "rusoto_core 0.39.0 (git+https://github.com/basisai/rusoto.git?rev=c1965504b483d1b086844a28742778cc64467863)",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1897,7 +1897,7 @@ dependencies = [
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf"
-"checksum aws-auth-payload 0.1.0 (git+https://github.com/lawliet89/aws-auth-payload?rev=63eaf88856b284b4864f46e578e5aabb87d352a9)" = "<none>"
+"checksum aws-auth-payload 0.1.0 (git+https://github.com/lawliet89/aws-auth-payload?rev=a760bfd02bca926a9d7e5c66ed5779939dc98b29)" = "<none>"
 "checksum backtrace 0.3.30 (registry+https://github.com/rust-lang/crates.io-index)" = "ada4c783bb7e7443c14e0480f429ae2cc99da95065aeab7ee1b81ada0419404f"
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
@@ -2018,8 +2018,8 @@ dependencies = [
 "checksum regex-syntax 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d76410686f9e3a17f06128962e0ecc5755870bb890c34820c7af7f1db2e1d48"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum reqwest 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)" = "00eb63f212df0e358b427f0f40aa13aaea010b470be642ad422bcbca2feff2e4"
-"checksum rusoto_core 0.39.0 (git+https://github.com/basisai/rusoto.git?rev=5a66c42296063ff021273827f12e629ae60a4716)" = "<none>"
-"checksum rusoto_credential 0.39.0 (git+https://github.com/basisai/rusoto.git?rev=5a66c42296063ff021273827f12e629ae60a4716)" = "<none>"
+"checksum rusoto_core 0.39.0 (git+https://github.com/basisai/rusoto.git?rev=c1965504b483d1b086844a28742778cc64467863)" = "<none>"
+"checksum rusoto_credential 0.39.0 (git+https://github.com/basisai/rusoto.git?rev=c1965504b483d1b086844a28742778cc64467863)" = "<none>"
 "checksum rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f4dccf6f4891ebcc0c39f9b6eb1a83b9bf5d747cb439ec6fba4f3b977038af"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "b96a9549dc8d48f2c283938303c4b5a77aa29bfbc5b54b084fb1630408899a8f"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "argon2rs"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "arrayref"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "arrayvec"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,6 +62,23 @@ dependencies = [
 name = "autocfg"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "aws-auth-payload"
+version = "0.1.0"
+source = "git+https://github.com/lawliet89/aws-auth-payload?rev=763babe2a5a257dc37060cb450c0b23a13bd4fdf#763babe2a5a257dc37060cb450c0b23a13bd4fdf"
+dependencies = [
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_core 0.39.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_sts 0.39.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "backtrace"
@@ -67,6 +103,15 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "base64"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -79,8 +124,31 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "blake2-rfc"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "build_const"
 version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byte-tools"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -115,6 +183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -139,6 +208,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cookie"
@@ -236,6 +310,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "digest"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "dirs"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_users 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "dtoa"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,6 +394,11 @@ dependencies = [
  "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "flate2"
@@ -356,6 +462,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "h2"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,6 +484,20 @@ dependencies = [
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "string 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hex"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "hmac"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crypto-mac 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -518,6 +646,11 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "md5"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "memchr"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +716,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio-named-pipes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mio-uds"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "miow"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -591,6 +745,15 @@ dependencies = [
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "socket2 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -910,6 +1073,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "regex"
 version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,6 +1144,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusoto_core"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hmac 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "md5 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_credential 0.39.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rusoto_credential"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-process 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rusoto_sts"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_core 0.39.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,6 +1222,11 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "safemem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "schannel"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,6 +1234,11 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "scoped_threadpool"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "scopeguard"
@@ -1073,6 +1317,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "shlex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "signal-hook"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signal-hook-registry 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arc-swap 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,6 +1364,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "smallvec"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "socket2"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -1193,14 +1482,19 @@ dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-fs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-trace-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-udp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1211,6 +1505,16 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-codec"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1232,6 +1536,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-fs"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tokio-io"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1239,6 +1553,21 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-process"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio-named-pipes 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-signal 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1257,6 +1586,22 @@ dependencies = [
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-signal"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signal-hook 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1317,6 +1662,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-udp"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-uds"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1328,6 +1704,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ucd-util"
@@ -1403,22 +1784,25 @@ dependencies = [
 name = "vault-k8s-helper"
 version = "0.2.0"
 dependencies = [
+ "aws-auth-payload 0.1.0 (git+https://github.com/lawliet89/aws-auth-payload?rev=763babe2a5a257dc37060cb450c0b23a13bd4fdf)",
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_core 0.39.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "vault-rs 0.1.0 (git+https://github.com/lawliet89/vault-rs?rev=543e7731eaebebebb477483b7079239cd7d8b1ae)",
+ "vault-rs 0.1.0 (git+https://github.com/lawliet89/vault-rs?rev=416d4f0fa704af36f5116ebd8b8d37e483658922)",
 ]
 
 [[package]]
 name = "vault-rs"
 version = "0.1.0"
-source = "git+https://github.com/lawliet89/vault-rs?rev=543e7731eaebebebb477483b7079239cd7d8b1ae#543e7731eaebebebb477483b7079239cd7d8b1ae"
+source = "git+https://github.com/lawliet89/vault-rs?rev=416d4f0fa704af36f5116ebd8b8d37e483658922#416d4f0fa704af36f5116ebd8b8d37e483658922"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1509,18 +1893,34 @@ dependencies = [
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "xml-rs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
 "checksum aho-corasick 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e6f484ae0c99fec2e858eb6134949117399f222608d84cadb3f58c1f97c2364c"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum arc-swap 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "bc4662175ead9cd84451d5c35070517777949a2ed84551764129cedb88384841"
+"checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
+"checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf"
+"checksum aws-auth-payload 0.1.0 (git+https://github.com/lawliet89/aws-auth-payload?rev=763babe2a5a257dc37060cb450c0b23a13bd4fdf)" = "<none>"
 "checksum backtrace 0.3.30 (registry+https://github.com/rust-lang/crates.io-index)" = "ada4c783bb7e7443c14e0480f429ae2cc99da95065aeab7ee1b81ada0419404f"
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+"checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
+"checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
+"checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
+"checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 "checksum cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d"
@@ -1528,6 +1928,7 @@ dependencies = [
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
 "checksum cookie_store 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46750b3f362965f197996c4448e4a0935e791bf7d6631bfce9ee0af3d24c919c"
 "checksum core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
@@ -1538,6 +1939,9 @@ dependencies = [
 "checksum crossbeam-epoch 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "04c9e3102cc2d69cd681412141b390abd55a362afc1540965dad0ad4d34280b4"
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
 "checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
+"checksum crypto-mac 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0999b4ff4d3446d4ddb19a63e9e00c1876e75cd7000d20e57a693b4b3f08d958"
+"checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
+"checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
 "checksum encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4155785c79f2f6701f185eb2e6b4caf0555ec03477cb4c70db67b465311620ed"
@@ -1545,6 +1949,7 @@ dependencies = [
 "checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
+"checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum flate2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f87e68aa82b2de08a6e037f1385455759df6e445a8df5e005b4297191dbf18aa"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
@@ -1554,7 +1959,10 @@ dependencies = [
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)" = "a2037ec1c6c1c4f79557762eab1f7eae1f64f6cb418ace90fae88f0942b60139"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
+"checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum h2 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)" = "1e42e3daed5a7e17b12a0c23b5b2fbff23a925a570938ebee4baca1a9a1a2240"
+"checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
+"checksum hmac 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44f3bdb08579d99d7dc761c0e266f13b5f2ab8c8c703b9fc9ef333cd8f48f55e"
 "checksum http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "eed324f0f0daf6ec10c474f150505af2c143f251722bf9dbd1261bd1f2ee2c1a"
 "checksum http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
@@ -1571,6 +1979,7 @@ dependencies = [
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+"checksum md5 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "79c56d6a0b07f9e19282511c83fc5b086364cbae4ba8c7d5f190c3d9b0425a48"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "3e27ca21f40a310bd06d9031785f4801710d566c184a6e15bad4f1d9b65f9425"
@@ -1578,7 +1987,10 @@ dependencies = [
 "checksum miniz_oxide 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c468f2369f07d651a5d0bb2c9079f8488a66d5466efe42d0c5c6466edcb7f71e"
 "checksum miniz_oxide_c_api 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b7fe927a42e3807ef71defb191dc87d4e24479b221e67015fe38ae2b7b447bab"
 "checksum mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)" = "83f51996a3ed004ef184e16818edc51fadffe8e7ca68be67f9dee67d84d0ff23"
+"checksum mio-named-pipes 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f5e374eff525ce1c5b7687c4cef63943e7686524a387933ad27ca7ec43779cb3"
+"checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+"checksum miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226"
 "checksum native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
@@ -1615,14 +2027,20 @@ dependencies = [
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)" = "12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
+"checksum redox_users 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe5204c3a17e97dde73f285d49be585df59ed84b50a872baf416e73b62c3828"
 "checksum regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0b2f0808e7d7e4fb1cb07feb6ff2f4bc827938f24f8c2e6a3beb7370af544bdd"
 "checksum regex-syntax 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d76410686f9e3a17f06128962e0ecc5755870bb890c34820c7af7f1db2e1d48"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum reqwest 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)" = "00eb63f212df0e358b427f0f40aa13aaea010b470be642ad422bcbca2feff2e4"
+"checksum rusoto_core 0.39.0 (registry+https://github.com/rust-lang/crates.io-index)" = "42753f93bf02ca5d177b85dfbfde7e8011ee330b3a5576584b99da3443d26da8"
+"checksum rusoto_credential 0.39.0 (registry+https://github.com/rust-lang/crates.io-index)" = "adbb49748d537ead58aa70042655ce730ea4da511babbb9e7238a869b9d240ea"
+"checksum rusoto_sts 0.39.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8651edfe8e1029b6057e6c28321ac9b95d3660ac3848e4bbcf9d8bbd1a7ed4df"
 "checksum rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f4dccf6f4891ebcc0c39f9b6eb1a83b9bf5d747cb439ec6fba4f3b977038af"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "b96a9549dc8d48f2c283938303c4b5a77aa29bfbc5b54b084fb1630408899a8f"
+"checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum schannel 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "f2f6abf258d99c3c1c5c2131d99d064e94b7b3dd5f416483057f308fea253339"
+"checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum security-framework 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eee63d0f4a9ec776eeb30e220f0bc1e092c3ad744b2a379e3993070364d3adc2"
 "checksum security-framework-sys 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9636f8989cbf61385ae4824b98c1aaa54c994d7d8b41f11c601ed799f0549a56"
@@ -1632,9 +2050,14 @@ dependencies = [
 "checksum serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)" = "46a3223d0c9ba936b61c0d2e3e559e3217dbfb8d65d06d26e8b3c25de38bae3e"
 "checksum serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "5a23aa71d4a4d43fdbfaac00eff68ba8a06a51759a89ac3304323e800c4dd40d"
 "checksum serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a"
+"checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
+"checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
+"checksum signal-hook 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "72ab58f1fda436857e6337dcb6a5aaa34f16c5ddc87b3a8b6ef7a212f90b9c5a"
+"checksum signal-hook-registry 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cded4ffa32146722ec54ab1f16320568465aa922aa9ab4708129599740da85d7"
 "checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
+"checksum socket2 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "4e626972d3593207547f14bf5fc9efa4d0e7283deb73fef1dff313dae9ab8878"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum string 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0bbfb8937e38e34c3444ff00afb28b0811d9554f15c5ad64d12b0308d1d1995"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
@@ -1648,17 +2071,24 @@ dependencies = [
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "ec2ffcf4bcfc641413fa0f1427bf8f91dfc78f56a6559cbf50e04837ae442a87"
 "checksum tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
+"checksum tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"
 "checksum tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d16217cad7f1b840c5a97dfb3c43b0c871fef423a6e8d2118c604e843662a443"
 "checksum tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "83ea44c6c0773cc034771693711c35c677b4b5a4b21b9e7071704c54de7d555e"
+"checksum tokio-fs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe6dc22b08d6993916647d108a1a7d15b9cd29c4f4496c62b92c45b5041b7af"
 "checksum tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5090db468dad16e1a7a54c8c67280c5e4b544f3d3e018f0b913b400261f85926"
+"checksum tokio-process 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "88e1281e412013f1ff5787def044a9577a0bed059f451e835f1643201f8b777d"
 "checksum tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6af16bfac7e112bea8b0442542161bfc41cbfa4466b580bdda7d18cb88b911ce"
+"checksum tokio-signal 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "dd6dc5276ea05ce379a16de90083ec80836440d5ef8a6a39545a3207373b8296"
 "checksum tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2162248ff317e2bc713b261f242b69dbb838b85248ed20bb21df56d60ea4cae7"
 "checksum tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1d14b10654be682ac43efee27401d792507e30fd8d26389e1da3b185de2e4119"
 "checksum tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72558af20be886ea124595ea0f806dd5703b8958e4705429dd58b3d8231f72f2"
 "checksum tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f2106812d500ed25a4f38235b9cae8f78a09edf43203e16e59c3b769a342a60e"
 "checksum tokio-trace-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9c8a256d6956f7cb5e2bdfe8b1e8022f1a09206c6c2b1ba00f3b746b260c613"
+"checksum tokio-udp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "66268575b80f4a4a710ef83d087fdfeeabdce9b74c797535fbac18a2cb906e92"
+"checksum tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b"
+"checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
 "checksum unicase 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a84e5511b2a947f3ae965dcb29b13b7b1691b6e7332cf5dbc1744138d5acb7f6"
@@ -1669,7 +2099,7 @@ dependencies = [
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum utf8-ranges 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9d50aa7650df78abf942826607c62468ce18d9019673d4a2ebe1865dbb96ffde"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
-"checksum vault-rs 0.1.0 (git+https://github.com/lawliet89/vault-rs?rev=543e7731eaebebebb477483b7079239cd7d8b1ae)" = "<none>"
+"checksum vault-rs 0.1.0 (git+https://github.com/lawliet89/vault-rs?rev=416d4f0fa704af36f5116ebd8b8d37e483658922)" = "<none>"
 "checksum vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
@@ -1682,3 +2112,4 @@ dependencies = [
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+"checksum xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c1cb601d29fe2c2ac60a2b2e5e293994d87a1f6fa9687a31a15270f909be9c2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,7 +1400,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "vault-gke-helper"
+name = "vault-k8s-helper"
 version = "0.2.0"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,13 +1412,13 @@ dependencies = [
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "vault-rs 0.1.0 (git+https://github.com/lawliet89/vault-rs?rev=ae5dd87b6319a2e616eae402f4b3fc63dbde0d24)",
+ "vault-rs 0.1.0 (git+https://github.com/lawliet89/vault-rs?rev=543e7731eaebebebb477483b7079239cd7d8b1ae)",
 ]
 
 [[package]]
 name = "vault-rs"
 version = "0.1.0"
-source = "git+https://github.com/lawliet89/vault-rs?rev=ae5dd87b6319a2e616eae402f4b3fc63dbde0d24#ae5dd87b6319a2e616eae402f4b3fc63dbde0d24"
+source = "git+https://github.com/lawliet89/vault-rs?rev=543e7731eaebebebb477483b7079239cd7d8b1ae#543e7731eaebebebb477483b7079239cd7d8b1ae"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1669,7 +1669,7 @@ dependencies = [
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum utf8-ranges 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9d50aa7650df78abf942826607c62468ce18d9019673d4a2ebe1865dbb96ffde"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
-"checksum vault-rs 0.1.0 (git+https://github.com/lawliet89/vault-rs?rev=ae5dd87b6319a2e616eae402f4b3fc63dbde0d24)" = "<none>"
+"checksum vault-rs 0.1.0 (git+https://github.com/lawliet89/vault-rs?rev=543e7731eaebebebb477483b7079239cd7d8b1ae)" = "<none>"
 "checksum vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Yong Wen Chua <lawliet89@users.noreply.github.com>"]
 edition = "2018"
 
 [dependencies]
-aws_auth = { git = "https://github.com/lawliet89/aws-auth-payload", package = "aws-auth-payload", rev = "63eaf88856b284b4864f46e578e5aabb87d352a9" }
+aws_auth = { git = "https://github.com/lawliet89/aws-auth-payload", package = "aws-auth-payload", rev = "a760bfd02bca926a9d7e5c66ed5779939dc98b29" }
 base64 = "0.10.1"
 clap = "2.33.0"
 chrono = "0.4.6"
@@ -13,7 +13,7 @@ env_logger = "0.6.1"
 failure = { version = "0.1.5", features=["backtrace"] }
 reqwest = "0.9.17"
 # rusoto_core = "0.39.0"
-rusoto_core = { git = "https://github.com/basisai/rusoto.git", rev = "5a66c42296063ff021273827f12e629ae60a4716" }
+rusoto_core = { git = "https://github.com/basisai/rusoto.git", rev = "c1965504b483d1b086844a28742778cc64467863" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "vault-gke-helper"
+name = "vault-k8s-helper"
 version = "0.2.0"
 authors = ["Yong Wen Chua <lawliet89@users.noreply.github.com>"]
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,13 +5,16 @@ authors = ["Yong Wen Chua <lawliet89@users.noreply.github.com>"]
 edition = "2018"
 
 [dependencies]
+aws_auth = { git = "https://github.com/lawliet89/aws-auth-payload", package = "aws-auth-payload", rev = "763babe2a5a257dc37060cb450c0b23a13bd4fdf" }
+base64 = "0.10.1"
 clap = "2.33.0"
 chrono = "0.4.6"
 env_logger = "0.6.1"
 failure = { version = "0.1.5", features=["backtrace"] }
 reqwest = "0.9.17"
+rusoto_core = "0.39.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 log = "0.4"
 url = "1.7.2"
-vault = { git = "https://github.com/lawliet89/vault-rs", package = "vault-rs", rev = "543e7731eaebebebb477483b7079239cd7d8b1ae" }
+vault = { git = "https://github.com/lawliet89/vault-rs", package = "vault-rs", rev = "416d4f0fa704af36f5116ebd8b8d37e483658922" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,16 +5,17 @@ authors = ["Yong Wen Chua <lawliet89@users.noreply.github.com>"]
 edition = "2018"
 
 [dependencies]
-aws_auth = { git = "https://github.com/lawliet89/aws-auth-payload", package = "aws-auth-payload", rev = "763babe2a5a257dc37060cb450c0b23a13bd4fdf" }
+aws_auth = { git = "https://github.com/lawliet89/aws-auth-payload", package = "aws-auth-payload", rev = "63eaf88856b284b4864f46e578e5aabb87d352a9" }
 base64 = "0.10.1"
 clap = "2.33.0"
 chrono = "0.4.6"
 env_logger = "0.6.1"
 failure = { version = "0.1.5", features=["backtrace"] }
 reqwest = "0.9.17"
-rusoto_core = "0.39.0"
+# rusoto_core = "0.39.0"
+rusoto_core = { git = "https://github.com/basisai/rusoto.git", rev = "5a66c42296063ff021273827f12e629ae60a4716" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 log = "0.4"
 url = "1.7.2"
-vault = { git = "https://github.com/lawliet89/vault-rs", package = "vault-rs", rev = "416d4f0fa704af36f5116ebd8b8d37e483658922" }
+vault = { git = "https://github.com/lawliet89/vault-rs", package = "vault-rs", rev = "34a6c73b900114fdfdbf0597c66f1e324e894012" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 log = "0.4"
 url = "1.7.2"
-vault = { git = "https://github.com/lawliet89/vault-rs", package = "vault-rs", rev = "ae5dd87b6319a2e616eae402f4b3fc63dbde0d24" }
+vault = { git = "https://github.com/lawliet89/vault-rs", package = "vault-rs", rev = "543e7731eaebebebb477483b7079239cd7d8b1ae" }

--- a/README.md
+++ b/README.md
@@ -63,8 +63,10 @@ ARGS:
 
 ### Example output
 
+#### GKE
+
 ```json
-{ "expires_at_seconds": "2019-03-01T08:09:32Z", "token": "ya29.c.<REDACTED>" }
+{ "token_expiry": "2019-03-01T08:09:32Z", "token": "ya29.c.<REDACTED>" }
 ```
 
 ## Tests
@@ -79,7 +81,9 @@ Provide the usual environment variables plus:
 
 ## Kube Config
 
-The following template for Kube Config would work well:
+The following template for Kube Config would work well.
+
+### GKE
 
 ```yaml
 apiVersion: v1
@@ -105,10 +109,10 @@ users:
             --vault-token-file=/path/to/vault/token
             --vault-address=https://vault.service.consul:8200
             --vault-ca-cert=/path/to/cert
-            gcp/token/roleset
+            gke gcp/token/roleset
 
         cmd-path: /bin/path/to/vault-gke-helper
-        expiry-key: '{.expires_at_seconds}'
+        expiry-key: '{.token_expiry}'
         token-key: '{.token}'
       name: gcp
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# GKE Helper
+# Vault Kubernetes Helper
 
-An authentication provider for GKE that reads access tokens from Vault.
+An authentication provider for Kubernetes that reads access tokens from Vault for
+Google Kubernetes Engine (GKE) or Elastic Kubernetes Service (EKS).
 
 ## Install
 
@@ -8,15 +9,23 @@ Get prebuilt binary from release page
 
 ```bash
 # Make it executable
-chmod +x vault-gke-helper
+chmod +x vault-k8s-helper
 ```
 
 ## Usage
+
+### GKE
 
 You have to configure Vault's
 [Google Cloud Secrets Engine](https://www.vaultproject.io/docs/secrets/gcp/index.html) first with
 an appropriate
 [access token roleset](https://www.vaultproject.io/docs/secrets/gcp/index.html#access-tokens).
+
+### AWS
+
+You have to configure Vault's
+[AWS Secrets Engine](https://www.vaultproject.io/docs/secrets/aws/index.html)
+with an appropriate role. Any role type should work.
 
 ```text
 Read Google Cloud Platform access token from Vault

--- a/README.md
+++ b/README.md
@@ -106,11 +106,13 @@ ARGS:
 
 You have to use a real Vault server with a configured
 [Google Cloud Secrets Engine](https://www.vaultproject.io/docs/secrets/gcp/index.html)
-[access token roleset](https://www.vaultproject.io/docs/secrets/gcp/index.html#access-tokens).
+[access token roleset](https://www.vaultproject.io/docs/secrets/gcp/index.html#access-tokens)
+and AWS Secrets Engine Role.
 
 Provide the usual environment variables plus:
 
-- `GCP_PATH` for the path to read the secrets from
+- `GCP_PATH` for the path to a GCP Secrets Engine credential endpoint for a token Roleset
+- `AWS_PATH` for the path to a AWS Secrets Engine credential endpoint for a role
 
 ## Kube Config
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ You have to configure Vault's
 with an appropriate role. Any role type should work.
 
 ```text
-Read Google Cloud Platform access token from Vault
+Read access tokens from Vault to authenticate with Kubernetes
 
 USAGE:
-    vault-gke-helper [OPTIONS] <path>
+    vault-k8s-helper [OPTIONS] <type> <path>
 
 FLAGS:
     -h, --help
@@ -42,6 +42,15 @@ FLAGS:
 
 
 OPTIONS:
+        --eks-role-arn <eks_role_arn>
+            The ARN of the role to assume if the AWS Secrets Engine role is configured with multiple roles
+
+        --eks-ttl <eks_ttl>
+            Specifies the TTL for the use of the STS token.
+
+        --output <output>
+            Change to path to output the credentials to. Defaults to `-` which is stdout [default: -]
+
         --vault-address <vault_address>
             Specifies the Vault Address to connect to. Include the scheme and port. Can be provided by the `VAULT_ADDR`
             environment variable as well
@@ -56,6 +65,9 @@ OPTIONS:
 
 
 ARGS:
+    <type>
+            Type of credentials to read [possible values: gke, eks]
+
     <path>
             Path to read from Vault
 
@@ -67,6 +79,12 @@ ARGS:
 
 ```json
 { "token_expiry": "2019-03-01T08:09:32Z", "token": "ya29.c.<REDACTED>" }
+```
+
+#### EKS
+
+```json
+
 ```
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ ARGS:
 
     <path>
             Path to read from Vault
-
 ```
 
 ### Example output

--- a/README.md
+++ b/README.md
@@ -14,19 +14,6 @@ chmod +x vault-k8s-helper
 
 ## Usage
 
-### GKE
-
-You have to configure Vault's
-[Google Cloud Secrets Engine](https://www.vaultproject.io/docs/secrets/gcp/index.html) first with
-an appropriate
-[access token roleset](https://www.vaultproject.io/docs/secrets/gcp/index.html#access-tokens).
-
-### AWS
-
-You have to configure Vault's
-[AWS Secrets Engine](https://www.vaultproject.io/docs/secrets/aws/index.html)
-with an appropriate role. Any role type should work.
-
 ```text
 Read access tokens from Vault to authenticate with Kubernetes
 
@@ -79,6 +66,33 @@ ARGS:
 
     <path>
             Path to read from Vault
+```
+
+### GKE
+
+You have to configure Vault's
+[Google Cloud Secrets Engine](https://www.vaultproject.io/docs/secrets/gcp/index.html) first with
+an appropriate
+[access token roleset](https://www.vaultproject.io/docs/secrets/gcp/index.html#access-tokens).
+
+```bash
+VAULT_TOKEN="s.xxx" \
+VAULT_ADDR="https://vault.service.consul:8200" \
+VAULT_CACERT=/path/to/ca \
+vault-k8s-helper gke gcp/token/roleset
+```
+
+### AWS
+
+You have to configure Vault's
+[AWS Secrets Engine](https://www.vaultproject.io/docs/secrets/aws/index.html)
+with an appropriate role. Any role type should work.
+
+```bash
+VAULT_TOKEN="s.xxx" \
+VAULT_ADDR="https://vault.service.consul:8200" \
+VAULT_CACERT=/path/to/ca \
+vault-k8s-helper eks --eks-cluster my_cluster aws/creds/role
 ```
 
 ### Example output

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -58,12 +58,12 @@ pub fn read_aws_credentials<S: AsRef<str>>(
     ))
 }
 
-pub fn get_eks_token(
+pub fn generate_presigned_url(
     credentials: &AwsCredentials,
     cluster: &str,
     region: Option<&str>,
     expires_in: Option<&str>,
-) -> Result<EksCredential, Error> {
+) -> Result<String, Error> {
     let region: Option<rusoto_core::region::Region> = match region {
         Some(r) => Some(r.parse()?),
         None => None,
@@ -73,11 +73,24 @@ pub fn get_eks_token(
         None => None,
     };
     let headers = [("x-k8s-aws-id", cluster)].iter().cloned().collect();
+    Ok(aws_auth::client::presigned_url(
+        credentials,
+        region,
+        headers,
+        expiry.as_ref(),
+    ))
+}
+
+pub fn get_eks_token(
+    credentials: &AwsCredentials,
+    cluster: &str,
+    region: Option<&str>,
+    expires_in: Option<&str>,
+) -> Result<EksCredential, Error> {
+    let url = generate_presigned_url(credentials, cluster, region, expires_in)?;
+    debug!("Generated AWS Pre-signed URL: {}", url);
 
     let mut token = "k8s-aws-v1.".to_string();
-
-    let url = aws_auth::client::presigned_url(credentials, region, headers, expiry.as_ref());
-    debug!("Generated AWS Pre-signed URL: {}", url);
     base64::encode_config_buf(&url, base64::URL_SAFE_NO_PAD, &mut token);
 
     Ok(EksCredential {
@@ -98,13 +111,29 @@ mod tests {
         env::var("AWS_PATH").expect("Provide Path to AWS role in AWS_PATH variable")
     }
 
-    #[test]
-    fn can_read_aws_secret() {
+    fn aws_credentials() -> rusoto_core::credential::AwsCredentials {
         let client = crate::tests::vault_client();
+        read_aws_credentials(&client, &aws_path(), &Default::default()).unwrap()
+    }
 
-        let aws_credentials =
-            read_aws_credentials(&client, &aws_path(), &Default::default()).unwrap();
-        debug!("AWS Credentials: {:#?}", aws_credentials);
+    #[test]
+    fn presigned_url_is_valid() {
+        let aws_credentials = aws_credentials();
+        let url = generate_presigned_url(&aws_credentials, "foobar", None, None).unwrap();
+
+        // We try to make the call to the pre-signed URL and it should succeed with 200
+        let client = reqwest::Client::new();
+        let response = client
+            .get(&url)
+            .header("x-k8s-aws-id", "foobar")
+            .send()
+            .unwrap();
+        assert!(response.status().is_success());
+    }
+
+    #[test]
+    fn can_create_aws_token() {
+        let aws_credentials = aws_credentials();
         let _ = get_eks_token(&aws_credentials, "test", None, None).unwrap();
     }
 }

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -1,0 +1,76 @@
+use std::collections::HashMap;
+
+use rusoto_core::credential::AwsCredentials;
+use serde::{Deserialize, Serialize};
+use vault::secrets::Aws;
+use vault::{self, Client};
+
+use crate::Error;
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct EksCredential {
+    pub kind: &'static str,
+    #[serde(rename = "apiVersion")]
+    pub api_version: &'static str,
+    pub spec: HashMap<(), ()>,
+    pub status: EksCredentialStatus,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct EksCredentialStatus {
+    pub token: String,
+}
+
+pub fn read_aws_credentials<S: AsRef<str>>(
+    client: &Client,
+    path: S,
+    request: &vault::secrets::aws::CredentialsRequest,
+) -> Result<AwsCredentials, Error> {
+    let path_parts: Vec<_> = path.as_ref().split('/').collect();
+    if path_parts.len() != 3 {
+        Err(Error::InvalidVaultPath)?;
+    }
+    if path_parts[1] != "creds" {
+        Err(Error::InvalidVaultPath)?;
+    }
+
+    let mount_point = path_parts[0];
+    let role = path_parts[2];
+
+    let creds = Aws::generate_credentials(&client, mount_point, role, request)?;
+    Ok(AwsCredentials::new(
+        creds.access_key,
+        creds.secret_key,
+        creds.security_token,
+        None,
+    ))
+}
+
+pub fn get_eks_token(
+    credentials: &AwsCredentials,
+    cluster: &str,
+    region: Option<&str>,
+    expires_in: Option<&str>,
+) -> Result<EksCredential, Error> {
+    let region: Option<rusoto_core::region::Region> = match region {
+        Some(r) => Some(r.parse()?),
+        None => None,
+    };
+    let expiry = match expires_in {
+        Some(expiry) => Some(std::time::Duration::from_secs(expiry.parse()?)),
+        None => None,
+    };
+    let headers = [("x-k8s-aws-id", cluster)].iter().cloned().collect();
+
+    let mut token = "k8s-aws-v1.".to_string();
+
+    let url = aws_auth::client::presigned_url(credentials, region, headers, expiry.as_ref());
+    base64::encode_config_buf(&url, base64::URL_SAFE_NO_PAD, &mut token);
+
+    Ok(EksCredential {
+        kind: "ExecCredential",
+        api_version: "client.authentication.k8s.io/v1alpha1",
+        spec: Default::default(),
+        status: EksCredentialStatus { token },
+    })
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,6 +30,8 @@ pub enum Error {
     VaultError(#[cause] vault::Error),
     #[fail(display = "Invalid Credential Type")]
     InvalidCredentialType,
+    #[fail(display = "Vault credentials path is invalid")]
+    InvalidVaultPath,
 }
 
 impl From<reqwest::Error> for Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,6 +32,8 @@ pub enum Error {
     InvalidCredentialType,
     #[fail(display = "Vault credentials path is invalid")]
     InvalidVaultPath,
+    #[fail(display = "Invalid AWS Region: {}", _0)]
+    InvalidAwsRegion(#[cause] rusoto_core::region::ParseRegionError),
 }
 
 impl From<reqwest::Error> for Error {
@@ -79,5 +81,11 @@ impl From<std::string::FromUtf8Error> for Error {
 impl From<vault::Error> for Error {
     fn from(error: vault::Error) -> Self {
         Error::VaultError(error)
+    }
+}
+
+impl From<rusoto_core::region::ParseRegionError> for Error {
+    fn from(error: rusoto_core::region::ParseRegionError) -> Self {
+        Error::InvalidAwsRegion(error)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,6 +28,8 @@ pub enum Error {
     Utf8Error(#[cause] std::string::FromUtf8Error),
     #[fail(display = "Vault Error: {}", _0)]
     VaultError(#[cause] vault::Error),
+    #[fail(display = "Invalid Credential Type")]
+    InvalidCredentialType,
 }
 
 impl From<reqwest::Error> for Error {

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -1,0 +1,81 @@
+use std::fmt;
+
+use chrono::{DateTime, NaiveDateTime, SecondsFormat, Utc};
+use serde::{Serialize, Deserialize};
+use serde::de::{self, Deserializer, Visitor};
+use vault::{self, Client, Vault};
+
+use crate::Error;
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct GcpAccessToken {
+    #[serde(deserialize_with = "timestamp_to_iso")]
+    #[serde(rename(serialize = "token_expiry", deserialize = "expires_at_seconds"))]
+    pub expiry: String,
+    pub token: String,
+    #[serde(skip_serializing)]
+    pub token_ttl: u64,
+}
+
+fn timestamp_to_iso<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct TimestampVisitor;
+
+    impl<'de> Visitor<'de> for TimestampVisitor {
+        type Value = i64;
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("an integer")
+        }
+
+        fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(value)
+        }
+
+        fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            use std::i64;
+            use std::u64;
+            if value <= i64::MAX as u64 {
+                Ok(value as i64)
+            } else {
+                Err(E::custom(format!("i64 out of range: {}", value)))
+            }
+        }
+    }
+
+    let timestamp = deserializer.deserialize_i64(TimestampVisitor)?;
+    let dt = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(timestamp, 0), Utc);
+    Ok(dt.to_rfc3339_opts(SecondsFormat::Secs, true))
+}
+
+
+pub fn read_gcp_access_token<S: AsRef<str>>(client: &Client, path: S) -> Result<GcpAccessToken, Error> {
+    let response = client.get(path.as_ref())?;
+    let data = response.data()?;
+    Ok(data)
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::env;
+
+    fn gcp_path() -> String {
+        env::var("GCP_PATH").expect("Provide Path to GCP role in GCP_PATH variable")
+    }
+
+    #[test]
+    fn can_read_gcp_secrets() {
+        let client = crate::tests::vault_client();
+        read_gcp_access_token(&client, gcp_path()).unwrap();
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -260,6 +260,7 @@ fn main() -> Result<(), Error> {
                 ttl: args.value_of("eks_ttl").map(|s| s.to_string()),
             };
             let aws_credentials = aws::read_aws_credentials(&client, path, &request)?;
+            debug!("AWS Credentials: {:#?}", aws_credentials);
             let token = aws::get_eks_token(
                 &aws_credentials,
                 required_arg_value(&args, "eks_cluster"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,7 +147,7 @@ fn make_parser<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("output")
                 .long("--output")
-                .help("Path to output credentials to")
+                .help("Output Path")
                 .long_help(
                     "Change to path to output the credentials to. Defaults to `-` which is stdout",
                 )
@@ -157,7 +157,8 @@ fn make_parser<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("eks_role_arn")
                 .long("--eks-role-arn")
-                .help(
+                .help("AWS IAM Role ARN")
+                .long_help(
                     "The ARN of the role to assume if the AWS Secrets Engine role is configured \
                      with multiple roles",
                 )
@@ -166,13 +167,15 @@ fn make_parser<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("eks_ttl")
                 .long("--eks-ttl")
-                .help("Specifies the TTL for the use of the STS token.")
+                .help("STS Token TTL")
+                .long_help("Specifies the TTL for the use of the STS token.")
                 .takes_value(true),
         )
         .arg(
             Arg::with_name("eks_expiry")
                 .long("--eks-expiry")
-                .help(
+                .help("EKS Token Expiry")
+                .long_help(
                     "Specifies the Expiry duration in number of seconds for the Kubernetes Token.",
                 )
                 .takes_value(true),
@@ -180,19 +183,22 @@ fn make_parser<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("eks_cluster")
                 .long("--eks-cluster")
-                .help("Name of the EKS cluster. Required if type is `eks`")
+                .help("EKS Cluster Name")
+                .long_help("Name of the EKS cluster. Required if type is `eks`")
                 .takes_value(true)
                 .required_if("type", "eks"),
         )
         .arg(
             Arg::with_name("eks_region")
                 .long("--eks-region")
-                .help("Region of AWS to use. Defaults to the Global Endpoint")
+                .help("AWS Region")
+                .long_help("Region of AWS to use. Defaults to the Global Endpoint")
                 .takes_value(true),
         )
         .arg(
             Arg::with_name("type")
-                .help("Type of credentials to read")
+                .help("Credentials Type")
+                .long_help("Type of credentials to read")
                 .takes_value(true)
                 .possible_values(CRED_VARIANTS)
                 .index(1)
@@ -200,7 +206,8 @@ fn make_parser<'a, 'b>() -> App<'a, 'b> {
         )
         .arg(
             Arg::with_name("path")
-                .help("Path to read from Vault")
+                .help("Vault Path")
+                .long_help("Path to read from Vault")
                 .takes_value(true)
                 .index(2)
                 .required(true),


### PR DESCRIPTION
# Breaking Changes

- Binary is now called `vault-k8s-helper`
- GKE users must now add a new `gke` positional argument before the Vault Path
- The payload returned from GKE now has the expiry key named `token_expiry` instead of the previous `expires_at_seconds`

EKS reference: https://github.com/kubernetes-sigs/aws-iam-authenticator#api-authorization-from-outside-a-cluster