### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
           sudo apt-get install -y musl-tools gcc-aarch64-linux-gnu
           echo '[target.aarch64-unknown-linux-gnu]' > ~/.cargo/config.toml
           echo 'linker = "aarch64-linux-gnu-gcc"' >> ~/.cargo/config.toml
+          echo 'rustflags = ["-C", "target-feature=-crt-static"]' >> ~/.cargo/config.toml
       - name: Build
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
```bash
tunnel_1           | [entrypoint.sh:80] python launch_kube_tunnel.py -v -c gke_staging-core_asia-southeast1_staging-core -s hanqiao-tunnel -p 8000 -n deployment -u default -k /home/span/.ssh/id_ed25519.pub create
tunnel_1           | ERROR:root:exec: process returned 255. qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory
```
Testing if it solves the above error.