### PR TITLE
Revert "Update release.yml"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,6 @@ jobs:
           sudo apt-get install -y musl-tools gcc-aarch64-linux-gnu
           echo '[target.aarch64-unknown-linux-gnu]' > ~/.cargo/config.toml
           echo 'linker = "aarch64-linux-gnu-gcc"' >> ~/.cargo/config.toml
-          echo 'rustflags = ["-C", "target-feature=-crt-static"]' >> ~/.cargo/config.toml
       - name: Build
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
Reverts basisai/vault-k8s-helper#172

Previous build was good. It's the build arg that failed. https://github.com/basisai/span/pull/3420